### PR TITLE
New functions: oktaAddRoleTargetsByUserId and oktaDelRoleTargetsByUserId

### DIFF
--- a/Okta.psm1
+++ b/Okta.psm1
@@ -2439,7 +2439,7 @@ function oktaGetRoleTargetsByUserId()
     (
         [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
         [parameter(Mandatory=$true)][alias("userId")][ValidateLength(20,20)][String]$uid,
-        [parameter(Mandatory=$true)][alias("userId")][ValidateLength(20,20)][String]$rid
+        [parameter(Mandatory=$true)][alias("roleId")][ValidateLength(16,20)][String]$rid
     )
        
     [string]$resource = "/api/v1/users/" + $uid + "/roles/" + $rid + "/targets/groups"

--- a/Okta.psm1
+++ b/Okta.psm1
@@ -2460,6 +2460,62 @@ function oktaGetRoleTargetsByUserId()
     return $request
 }
 
+function oktaAddRoleTargetsByUserId()
+{
+    param
+    (
+        [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
+        [parameter(Mandatory=$true)][alias("userId")][ValidateLength(20,20)][String]$uid,
+        [parameter(Mandatory=$true)][alias("roleId")][ValidateLength(16,20)][String]$rid,
+        [parameter(Mandatory=$true)][alias("groupId")][ValidateLength(20,20)][String]$gid
+    )
+       
+    [string]$resource = "/api/v1/users/" + $uid + "/roles/" + $rid + "/targets/groups/" + $gid
+    [string]$method = "Put"
+    
+    try
+    {
+        $request = _oktaNewCall -method $method -resource $resource -oOrg $oOrg -enablePagination:$true
+    }
+    catch
+    {
+        if ($oktaVerbose -eq $true)
+        {
+            Write-Host -ForegroundColor red -BackgroundColor white $_.TargetObject
+        }
+        throw $_
+    }
+    return $request
+}
+
+function oktaDelRoleTargetsByUserId()
+{
+    param
+    (
+        [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
+        [parameter(Mandatory=$true)][alias("userId")][ValidateLength(20,20)][String]$uid,
+        [parameter(Mandatory=$true)][alias("roleId")][ValidateLength(16,20)][String]$rid,
+        [parameter(Mandatory=$true)][alias("groupId")][ValidateLength(20,20)][String]$gid
+    )
+       
+    [string]$resource = "/api/v1/users/" + $uid + "/roles/" + $rid + "/targets/groups/" + $gid
+    [string]$method = "Delete"
+    
+    try
+    {
+        $request = _oktaNewCall -method $method -resource $resource -oOrg $oOrg -enablePagination:$true
+    }
+    catch
+    {
+        if ($oktaVerbose -eq $true)
+        {
+            Write-Host -ForegroundColor red -BackgroundColor white $_.TargetObject
+        }
+        throw $_
+    }
+    return $request
+}
+
 function oktaAddUseridtoGroupid()
 {
     param

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ catch
 #### Available Commands
 
 - oktaActivateUserbyId
+- oktaAddRoleTargetsByUserId
 - oktaAddUseridtoGroupid
 - oktaAddUsertoRoles
 - oktaAdminExpirePasswordbyID
@@ -178,6 +179,7 @@ catch
 - oktaDeactivateUserbyID
 - oktaDeleteGroupbyId
 - oktaDeleteUserfromGroup
+- oktaDelRoleTargetsByUserId
 - oktaDelUserFromAllGroups
 - oktaDelUseridfromAppid
 - oktaDelUseridfromGroupid


### PR DESCRIPTION
Create two new functions oktaAddRoleTargetsByUserId and oktaDelRoleTargetsByUserId. These allow us to add and remove a group target for a USER_ADMIN or HELP_DESK_ADMIN roles.

As seen here: https://developer.okta.com/docs/api/resources/roles/#add-group-target-to-group-administrator-role