### PR TITLE
New function oktaUpdateGroupProfilebyID

### DIFF
--- a/Okta.psm1
+++ b/Okta.psm1
@@ -991,6 +991,50 @@ function oktaUpdateUserbyID()
     return $request
 }
 
+function oktaUpdateGroupProfilebyID()
+{
+    param
+    (
+        [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
+        [parameter(Mandatory=$true)][ValidateLength(20,20)][String]$gid,
+        [parameter(Mandatory=$false)][ValidateLength(1,255)][String]$name,
+        [parameter(Mandatory=$false)][ValidateLength(1,1024)][String]$description
+    )
+    [string]$method = "Put"
+    [string]$resource = "/api/v1/groups/" + $gid
+    if (!$name -and !$description)
+    {
+    throw ("Must specify name and/or description")
+    }
+    if (!$name)
+    {
+    $name = (oktaGetGroupbyId -oOrg $oOrg -gid $gid).profile.name
+    }
+    if (!$description)
+    {
+    $description = (oktaGetGroupbyId -oOrg $oOrg -gid $gid).profile.description
+    }
+    $psobj = @{
+        profile = @{
+            name = $name
+            description = $description
+        }
+      }
+    try
+    {
+    $request = _oktaNewCall -oOrg $oOrg -method $method -resource $resource -body $psobj
+    }
+    catch
+    {
+        if ($oktaVerbose -eq $true)
+        {
+            Write-Host -ForegroundColor red -BackgroundColor white $_.TargetObject
+        }
+        throw $_
+    }
+    return $request
+}
+
 function oktaChangePasswordbyID()
 {
    param

--- a/Okta.psm1
+++ b/Okta.psm1
@@ -4631,6 +4631,46 @@ function oktaListAppAssignments()
     return $request
 }
 
+function oktaUpdateGroupProfilebyID()
+{
+    param
+    (
+        [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
+        [parameter(Mandatory=$true)][ValidateLength(20,20)][String]$gid,
+        [parameter(Mandatory=$false)][ValidateLength(1,255)][String]$name,
+        [parameter(Mandatory=$false)][ValidateLength(1,1024)][String]$description
+    )
+    [string]$method = "Put"
+    [string]$resource = "/api/v1/groups/" + $gid
+    if ($null -eq $name)
+    {
+    $name = (oktaGetGroupbyId -oOrg $oOrg -gid $gid).profile.name
+    }
+    if ($null -eq $description)
+    {
+    $description = (oktaGetGroupbyId -oOrg $oOrg -gid $gid).profile.description
+    }
+    $psobj = @{
+        profile = @{
+            name = $name
+            description = $description
+        }
+      }
+    try
+    {
+    $request = _oktaNewCall -oOrg $oOrg -method $method -resource $resource -body $psobj
+    }
+    catch
+    {
+        if ($oktaVerbose -eq $true)
+        {
+            Write-Host -ForegroundColor red -BackgroundColor white $_.TargetObject
+        }
+        throw $_
+    }
+    return $request
+}
+
 ################## _links ###########################
 
 function oktaFetch_link()

--- a/Okta.psm1
+++ b/Okta.psm1
@@ -2509,6 +2509,60 @@ function oktaDelUserFromRoles()
     return $request
 }
 
+function oktaAddgroupIDtoAppID
+{
+    param
+    (
+        [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
+        [parameter(Mandatory=$true)][alias("groupID")][ValidateLength(20,20)][String]$gid,
+        [parameter(Mandatory=$true)][ValidateLength(20,20)][String]$aid
+    )
+        
+    [string]$resource = "/api/v1/apps/" + $aid + "/groups/" + $gid
+    [string]$method = "Put"
+    
+    try
+    {
+        $request = _oktaNewCall -method $method -resource $resource -oOrg $oOrg
+    }
+    catch
+    {
+        if ($oktaVerbose -eq $true)
+        {
+            Write-Host -ForegroundColor red -BackgroundColor white $_.TargetObject
+        }
+        throw $_
+    }
+    return $request
+}
+
+function oktaDelGroupIDfromAppID
+{
+    param
+    (
+        [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
+        [parameter(Mandatory=$true)][alias("groupID")][ValidateLength(20,20)][String]$gid,
+        [parameter(Mandatory=$true)][ValidateLength(20,20)][String]$aid
+    )
+        
+    [string]$resource = "/api/v1/apps/" + $aid + "/groups/" + $gid
+    [string]$method = "Delete"
+    
+    try
+    {
+        $request = _oktaNewCall -method $method -resource $resource -oOrg $oOrg
+    }
+    catch
+    {
+        if ($oktaVerbose -eq $true)
+        {
+            Write-Host -ForegroundColor red -BackgroundColor white $_.TargetObject
+        }
+        throw $_
+    }
+    return $request
+}
+
 function oktaGetRoleTargetsByUserId()
 {
     param

--- a/Okta.psm1
+++ b/Okta.psm1
@@ -1011,9 +1011,16 @@ function oktaUpdateGroupProfilebyID()
     $name = (oktaGetGroupbyId -oOrg $oOrg -gid $gid).profile.name
     }
     if (!$description)
-    {
-    $description = (oktaGetGroupbyId -oOrg $oOrg -gid $gid).profile.description
-    }
+	{
+		try
+		{
+		$description = (oktaGetGroupbyId -oOrg $oOrg -gid $gid).profile.description
+		}
+		catch
+		{
+		$description = " "
+		}
+	}
     $psobj = @{
         profile = @{
             name = $name

--- a/Okta.psm1
+++ b/Okta.psm1
@@ -2565,16 +2565,18 @@ function oktaGetRoleTargetsByUserId()
     param
     (
         [parameter(Mandatory=$false)][ValidateLength(1,100)][String]$oOrg=$oktaDefOrg,
-        [parameter(Mandatory=$true)][alias("userId")][ValidateLength(20,20)][String]$uid,
-        [parameter(Mandatory=$true)][alias("roleId")][ValidateLength(14,24)][String]$rid
+        [parameter(Mandatory=$true)][alias("userId")][ValidateLength(20,20)][String]$uid
     )
        
-    [string]$resource = "/api/v1/users/" + $uid + "/roles/" + $rid + "/targets/groups"
+    [string]$resource = "/api/internal/administrators/" + $uid
     [string]$method = "Get"
     
     try
     {
-        $request = _oktaNewCall -method $method -resource $resource -oOrg $oOrg -enablePagination:$true
+        $roledetails = _oktaNewCall -method $method -resource $resource -oOrg $oOrg -enablePagination:$true
+        $request = ForEach ($gid in ($roledetails).userAdminGroupIds) {
+            oktaGetGroupbyId -oOrg $oOrg -gid $gid
+        }
     }
     catch
     {

--- a/Okta.psm1
+++ b/Okta.psm1
@@ -460,13 +460,15 @@ function _oktaMakeCall()
     Write-Verbose("Req-Hdr: " + "User-Agent" + " -> " + $userAgent)
     try
     {
+        if ($body.Count -gt 0) {
+            $postData = ConvertTo-Json $body -Depth 10
+            Write-Verbose($postData)
+            }
         if (!$Global:myWebSession)
         {
             Write-Verbose("Creating myWebSession first")
             if ( ($method -eq "Post") -or ($method -eq "Put") )
             {
-                $postData = ConvertTo-Json $body -Depth 10
-                Write-Verbose($postData)
                 $request2 = Invoke-WebRequest -Uri $uri -Method $method -UserAgent $userAgent -Headers $headers `
                             -ContentType $contentType -Verbose:$oktaVerbose -Body $postData -ErrorVariable evar -SessionVariable Global:myWebSession
             } else {
@@ -476,8 +478,6 @@ function _oktaMakeCall()
         } else {
             if ( ($method -eq "Post") -or ($method -eq "Put") )
             {
-                $postData = ConvertTo-Json $body -Depth 10
-                Write-Verbose($postData)
                 $request2 = Invoke-WebRequest -Uri $uri -Method $method -UserAgent $userAgent -Headers $headers `
                             -ContentType $contentType -Verbose:$oktaVerbose -Body $postData -ErrorVariable evar -WebSession $Global:myWebSession
             } else {
@@ -2615,6 +2615,45 @@ function oktaDelUserFromRoles()
     try
     {
         $request = _oktaNewCall -method $method -resource $resource -oOrg $oOrg
+    }
+    catch
+    {
+        if ($oktaVerbose -eq $true)
+        {
+            Write-Host -ForegroundColor red -BackgroundColor white $_.TargetObject
+        }
+        throw $_
+    }
+    return $request
+}
+
+function oktaUpdateRoleNotification()
+{
+    param(
+        [parameter(ParameterSetName="user", mandatory=$true)]
+        [ValidateLength(20,20)][string]$uid,
+        [parameter(ParameterSetName="group", mandatory=$true)]
+        [ValidateLength(20,20)][string]$gid,
+        [parameter(ParameterSetName="user", mandatory=$true)]
+        [parameter(ParameterSetName="group", mandatory=$true)]
+        [ValidateSet('true','false')][string]$notification,
+        [parameter(ParameterSetName="user", mandatory=$false)]
+        [parameter(ParameterSetName="group", mandatory=$false)]
+        [ValidateLength(1,100)][string]$oOrg=$oktaDefOrg
+    )
+    
+    [string]$method = "Post"
+
+    if($uid) {
+        [string]$resource = "/api/v1/users/" + $uid + "/roles?disableNotifications=" + $notification
+    }
+    elseif($gid) {
+        [string]$resource = "/api/v1/groups/" + $gid + "/roles?disableNotifications=" + $notification
+    }
+
+    try
+    {
+        $request = _oktaNewCall -oOrg $oOrg -method $method -resource $resource -WarningAction SilentlyContinue
     }
     catch
     {

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ catch
 - oktaUpdateApp
 - oktaUpdateAppExternalIdbyUserId
 - oktaUpdateAppProfilebyUserId
+- oktaUpdateGroupProfilebyID
 - oktaUpdateUserbyID
 - oktaUpdateUserProfilebyID
 - oktaVerifyMFAnswerbyUser


### PR DESCRIPTION
The new function oktaUpdateGroupProfilebyID allows for the name and/or description of a group to be changed by specifying its unique ID.

Okta's API dictates that for this specific put request all details in the profile must be specified, if any are absent then that field will become blank https://developer.okta.com/docs/api/resources/groups/#update-group

Therefore I have ensured that the name and/or description strings must be provided and if one is absent the existing value will be retrieved to be sent in the put request. If neither are specified then an error will be thrown.