### PR TITLE
Update to allow multiple sessions in same PoSh Session

### DIFF
--- a/Okta.psm1
+++ b/Okta.psm1
@@ -440,6 +440,14 @@ function _oktaMakeCall()
         [parameter(Mandatory=$false)][String]$userAgent,
         [parameter(Mandatory=$false)][String]$contentType = "application/json"
     )
+    <# Lets build in a websession switcher #>
+    $oOrgVar = $uri.split(".")[0].split("//")[-1] # holds oOrg Info for state save
+    if ((Get-Variable -Name $("myWebSession" + $oOrgVar) -Scope Global -ErrorAction SilentlyContinue) -ne $null) {
+      $Global:myWebSession = (Get-Variable -Name $("myWebSession" + $oOrgVar) -Scope Global).value
+    } else {
+        # First Run Through
+    }
+    <# End Switcher #>
 
     if (!$userAgent)
     {
@@ -634,7 +642,11 @@ function _oktaMakeCall()
     }
 
     if ($rateLimt){ _oktaRateLimitCheck }
-    
+
+    <# Variable Switcher - save state #>
+    Set-Variable -Name $("myWebSession" + $oOrgVar) -value $(Get-Variable -Name "myWebSession"  -Scope Global).value -Scope Global
+    <# End - Save state#>
+
     return @{ result = $result ; next = $next ; ratelimit = $rateLimt }
 }
 


### PR DESCRIPTION
This edits _oktaMakeCall to check a state variable based on uri passed to the function to make a unique variable to hold state of websessions.  This allows the global:mywebsession variable to be saved at end of function and recalled for EACH org in the Okta_org.ps1.  Checking/Saving mywebsession at the start and end of that function allows multiple Okta Orgs to be called within the same Powershell Session.

TODO: There might be invalid characters possible in variable names resulting in unexpected behavior. I did not validate if URL host characters can be the same character space as powershell variable names.